### PR TITLE
Update docs mapview.md for fitToSuppliedMarkers 

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -57,7 +57,7 @@
 | `animateToRegion` | `region: Region`, `duration: Number` |
 | `animateToCoordinate` | `region: Coordinate`, `duration: Number` |
 | `fitToElements` | `animated: Boolean` |
-| `fitToSuppliedMarkers` | `markerIDs: String[]` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
+| `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` |
 
 


### PR DESCRIPTION
add non-optional `animated` parameter to the docs, closes #958